### PR TITLE
Rename publish: to published: in post frontmatter for v1.9.0 upgrade

### DIFF
--- a/content/posts/A Bond Created in Bondage.mdx
+++ b/content/posts/A Bond Created in Bondage.mdx
@@ -1,7 +1,7 @@
 ---
 author: Evelyn Reece
 title: A Bond Created in Bondage
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/A Brief Guide to Civil War Armies.mdx
+++ b/content/posts/A Brief Guide to Civil War Armies.mdx
@@ -1,7 +1,7 @@
 ---
 author: "Ian Iverson "
 title: A Brief Guide to Civil War Armies
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/A Complaint At McCoy's Boardinghouse (1855).mdx
+++ b/content/posts/A Complaint At McCoy's Boardinghouse (1855).mdx
@@ -1,7 +1,7 @@
 ---
 author: "Catherine A. Creighton, Undergraduate Research Assistant (History Degree) "
 title: A Complaint At McCoy's Boardinghouse (1855)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/A Fanatical Clamor: UVA Reacts to John Brown's Raid.mdx
+++ b/content/posts/A Fanatical Clamor: UVA Reacts to John Brown's Raid.mdx
@@ -1,7 +1,7 @@
 ---
 author: Gwen Dilworth
 title: 'A "Fanatical Clamor": UVA Reacts to John Brown''s Raid'
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/A Review of the Conditions of the Grounds (1849).mdx
+++ b/content/posts/A Review of the Conditions of the Grounds (1849).mdx
@@ -1,7 +1,7 @@
 ---
 author: Emily Richards, Undergraduate Research Assistant (Architecture, 3rd year)
 title: A Review of the Conditions of the Grounds (1849)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/A Reward for Honesty (1836).mdx
+++ b/content/posts/A Reward for Honesty (1836).mdx
@@ -1,7 +1,7 @@
 ---
 author: Alison Peltz, Undergraduate Research Assistant (Computer Science, 2nd year)
 title: A Reward for Honesty (1836)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/A Scholarship for State Students (1818).mdx
+++ b/content/posts/A Scholarship for State Students (1818).mdx
@@ -1,7 +1,7 @@
 ---
 author: Meghan Ellwood
 title: A Scholarship for State Students (1818)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/A Student Beats A Slave (1856).mdx
+++ b/content/posts/A Student Beats A Slave (1856).mdx
@@ -1,7 +1,7 @@
 ---
 author: "Catherine A. Creighton, Undergraduate Research Assistant (History Degree) "
 title: A Student Beats A Slave (1856)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/A Student Contests Judiciary Ruling of Faculty (1838).mdx
+++ b/content/posts/A Student Contests Judiciary Ruling of Faculty (1838).mdx
@@ -1,7 +1,7 @@
 ---
 author: Emily Richards, Undergraduate Research Assistant (Architecture, 3rd year)
 title: A Student Contests Judiciary Ruling of Faculty (1838)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/A Warm Welcome: Harriet Beecher Stowe Burned in Effigy by UVa Students, 1855.mdx
+++ b/content/posts/A Warm Welcome: Harriet Beecher Stowe Burned in Effigy by UVa Students, 1855.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ben Hitchcock
 title: "A Warm Welcome: Harriet Beecher Stowe Burned in Effigy by U.Va. Students, 1855"
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/A transect: School of Architecture course looks at Narratives of Slavery.mdx
+++ b/content/posts/A transect: School of Architecture course looks at Narratives of Slavery.mdx
@@ -1,7 +1,7 @@
 ---
 author: W.N. Martin
 title: 'A transect: School of Architecture course looks at "Narratives of Slavery"'
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Albert T Bledsoe: Mathematician, Theologian, and Proslavery Philosopher.mdx
+++ b/content/posts/Albert T Bledsoe: Mathematician, Theologian, and Proslavery Philosopher.mdx
@@ -1,7 +1,7 @@
 ---
 author: "Ian Iverson and Josh Morrison "
 title: "Albert T. Bledsoe: Mathematician, Theologian, and Proslavery Philosopher"
-publish: true
+published: true
 category: Biographies
 ---
 

--- a/content/posts/An Early Proposal for a University President (1826).mdx
+++ b/content/posts/An Early Proposal for a University President (1826).mdx
@@ -1,7 +1,7 @@
 ---
 author: "Catherine A. Creighton, Undergraduate Research Assistant (History Degree) "
 title: "An Early Proposal for a University President (1826) "
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Antebellum Virginia’s Evolution in Political Economy.mdx
+++ b/content/posts/Antebellum Virginia’s Evolution in Political Economy.mdx
@@ -1,7 +1,7 @@
 ---
 author: "Ian Iverson "
 title: Antebellum Virginia’s Evolution in Political Economy
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/Audit of Ledger.mdx
+++ b/content/posts/Audit of Ledger.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: Audit of Ledger
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Bernard Gaines Farrar Jr: University Student and Union Soldier.mdx
+++ b/content/posts/Bernard Gaines Farrar Jr: University Student and Union Soldier.mdx
@@ -1,7 +1,7 @@
 ---
 author: Olivia Beatty, Undergraduate Research Assistant (History, 3rd Year)
 title: "Bernard Gaines Farrar Jr.: University Student and Union Soldier"
-publish: true
+published: true
 category: Biographies
 ---
 

--- a/content/posts/Charles Ellis Jr: Biography of a Student (1817-1900).mdx
+++ b/content/posts/Charles Ellis Jr: Biography of a Student (1817-1900).mdx
@@ -1,5 +1,5 @@
 ---
-publish: true
+published: true
 category: Biographies
 title: 'Charles Ellis Jr.: Biography of a Student (1817-1900)'
 author: 'Catherine A. Creighton, Undergraduate Research Assistant (History Degree) '

--- a/content/posts/Did the murder of Professor John Davis bring the Honour Code to the University of Virginia.mdx
+++ b/content/posts/Did the murder of Professor John Davis bring the Honour Code to the University of Virginia.mdx
@@ -1,5 +1,5 @@
 ---
-publish: true
+published: true
 category: Daily Life
 title: >-
   Did the murder of Professor John Davis bring the Honour Code to the University

--- a/content/posts/Draffen's Tavern.mdx
+++ b/content/posts/Draffen's Tavern.mdx
@@ -1,7 +1,7 @@
 ---
 author: Erin Hernon
 title: Draffen's Tavern
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Enoch Faw visits Monticello.mdx
+++ b/content/posts/Enoch Faw visits Monticello.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ellen Adams
 title: Enoch Faw visits Monticello
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Fitch's Tavern.mdx
+++ b/content/posts/Fitch's Tavern.mdx
@@ -1,5 +1,5 @@
 ---
-publish: true
+published: true
 category: Daily Life
 title: Fitch's Tavern
 author: Erin Hernon

--- a/content/posts/Gossip So Good, Maria C Broadus Had To Share It Twice.mdx
+++ b/content/posts/Gossip So Good, Maria C Broadus Had To Share It Twice.mdx
@@ -1,7 +1,7 @@
 ---
 author: Brittany Acors
 title: Gossip So Good, Maria C. Broadus Had To Share It Twice
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Grave Robbing Instance in 1837.mdx
+++ b/content/posts/Grave Robbing Instance in 1837.mdx
@@ -1,7 +1,7 @@
 ---
 author: Meghan Ellwood
 title: Grave Robbing Instance in 1837
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Henry Clay Pate, Student (1832-1864).mdx
+++ b/content/posts/Henry Clay Pate, Student (1832-1864).mdx
@@ -1,7 +1,7 @@
 ---
 author: Camille Horton
 title: Henry Clay Pate, Student (1832-1864)
-publish: true
+published: true
 category: Biographies
 ---
 

--- a/content/posts/James Albert Harrison.mdx
+++ b/content/posts/James Albert Harrison.mdx
@@ -1,7 +1,7 @@
 ---
 author: Meghan Ellwood
 title: James Albert Harrison
-publish: true
+published: true
 category: Biographies
 ---
 

--- a/content/posts/James Ancrum Winslow: UVA Unionist.mdx
+++ b/content/posts/James Ancrum Winslow: UVA Unionist.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: "James Ancrum Winslow: UVA Unionist "
-publish: true
+published: true
 category: Biographies
 ---
 

--- a/content/posts/James M Deems: UVA Music Instructor and Union Army General.mdx
+++ b/content/posts/James M Deems: UVA Music Instructor and Union Army General.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: "James M. Deems: UVA Music Instructor and Union Army General"
-publish: true
+published: true
 category: Biographies
 ---
 

--- a/content/posts/James P Holcombe: Champion of Slavery and Secession.mdx
+++ b/content/posts/James P Holcombe: Champion of Slavery and Secession.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: "James P. Holcombe: Champion of Slavery and Secession"
-publish: true
+published: true
 category: Biographies
 ---
 

--- a/content/posts/John B Minor & the Tensions of Mastery.mdx
+++ b/content/posts/John B Minor & the Tensions of Mastery.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: John B. Minor & the Tensions of Mastery
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/John Hartwell Cocke.mdx
+++ b/content/posts/John Hartwell Cocke.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ellen Adams
 title: John Hartwell Cocke
-publish: true
+published: true
 category: Biographies
 ---
 

--- a/content/posts/Kitty Foster, Mr Vandergriff, and Student Mischief in the Venable Lane Neighborhood (1834).mdx
+++ b/content/posts/Kitty Foster, Mr Vandergriff, and Student Mischief in the Venable Lane Neighborhood (1834).mdx
@@ -1,7 +1,7 @@
 ---
 author: Emily Richards, Undergraduate Research Assistant (Architecture, 3rd year)
 title: Kitty Foster, Mr. Vandergriff, and Student Mischief in the Venable Lane Neighborhood (1834)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Lawrence of Hotel A.mdx
+++ b/content/posts/Lawrence of Hotel A.mdx
@@ -1,7 +1,7 @@
 ---
 author: Shivani Dimri
 title: Lawrence of Hotel A
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Marriage in the Civil War According to Eugene Blackford.mdx
+++ b/content/posts/Marriage in the Civil War According to Eugene Blackford.mdx
@@ -1,7 +1,7 @@
 ---
 author: Shivani Dimri
 title: Marriage in the Civil War According to Eugene Blackford
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Mr Forbes Kicks a Slave (1834).mdx
+++ b/content/posts/Mr Forbes Kicks a Slave (1834).mdx
@@ -1,7 +1,7 @@
 ---
 author: Emily Richards, Undergraduate Research Assistant (Architecture, 3rd year)
 title: Mr. Forbes Kicks a Slave (1834)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Mr Moon Throws a Knife at a Servant (1839).mdx
+++ b/content/posts/Mr Moon Throws a Knife at a Servant (1839).mdx
@@ -1,7 +1,7 @@
 ---
 author: Connor Andrews, Undergraduate Research Assistant (History, 3rd year)
 title: Mr. Moon Throws a Knife at a Servant (1839)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Nathaniel Beverly Tucker, A Notable Alumnus (1820-1890).mdx
+++ b/content/posts/Nathaniel Beverly Tucker, A Notable Alumnus (1820-1890).mdx
@@ -1,7 +1,7 @@
 ---
 author: Meredith Stanley, Undergraduate Research Assistant (Archaeology and American Studies, 2nd year)
 title: Nathaniel Beverly Tucker, A Notable Alumnus (1820-1890)
-publish: true
+published: true
 category: Biographies
 ---
 

--- a/content/posts/Offences, Punishment, and Early Student Self-Governance at the University (1824).mdx
+++ b/content/posts/Offences, Punishment, and Early Student Self-Governance at the University (1824).mdx
@@ -1,7 +1,7 @@
 ---
 author: "Catherine A. Creighton, Undergraduate Research Assistant (History Degree) "
 title: Offences, Punishment, and Early Student Self-Governance at the University (1824)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Partisan Politics in Virginia, 1819-1859.mdx
+++ b/content/posts/Partisan Politics in Virginia, 1819-1859.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: Partisan Politics in Virginia, 1819-1859
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/Pavilion X: A Brief History (1820-1895).mdx
+++ b/content/posts/Pavilion X: A Brief History (1820-1895).mdx
@@ -1,5 +1,5 @@
 ---
-publish: true
+published: true
 category: Architecture
 title: 'Pavilion X: A Brief History (1820-1895)'
 author: 'Catherine A. Creighton, Undergraduate Research Assistant (History Degree) '

--- a/content/posts/Pestilence and Privies: Original Outhouses of the University.mdx
+++ b/content/posts/Pestilence and Privies: Original Outhouses of the University.mdx
@@ -1,7 +1,7 @@
 ---
 author: Emily Richards, Undergraduate Research Assistant (Architecture, 3rd year)
 title: "Pestilence and Privies: Original Outhouses of the University"
-publish: true
+published: true
 category: Architecture
 ---
 

--- a/content/posts/Phil - hired out by John B Minor.mdx
+++ b/content/posts/Phil - hired out by John B Minor.mdx
@@ -1,7 +1,7 @@
 ---
 author: Zach Dolack
 title: Phil - hired out by John B. Minor
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Professor Bonnycastle's Slave is Beaten by Students (1839).mdx
+++ b/content/posts/Professor Bonnycastle's Slave is Beaten by Students (1839).mdx
@@ -1,7 +1,7 @@
 ---
 author: Thomas M. Winters, Graduate Research Assistant (Art History)
 title: Professor Bonnycastle's Slave is Beaten by Students (1839)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Prosecution vs Progress: Slave Courts in the 19th-century.mdx
+++ b/content/posts/Prosecution vs Progress: Slave Courts in the 19th-century.mdx
@@ -1,7 +1,7 @@
 ---
 author: Emma Hitchcock
 title: "Prosecution vs. Progress: Slave Courts in the 19th-century"
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Robert Garlick Hill Kean: Confederate Commentator.mdx
+++ b/content/posts/Robert Garlick Hill Kean: Confederate Commentator.mdx
@@ -1,7 +1,7 @@
 ---
 author: Rachel Gaffin, Undergraduate Research Assistant
 title: "Robert Garlick Hill Kean: Confederate Commentator"
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Robert MT Hunter's Fourth of July Address.mdx
+++ b/content/posts/Robert MT Hunter's Fourth of July Address.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ellen Adams
 title: Robert M.T. Hunter's Fourth of July Address
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Shakespeare and Scripture.mdx
+++ b/content/posts/Shakespeare and Scripture.mdx
@@ -1,7 +1,7 @@
 ---
 author: Christina Griggs, Undergraduate Research Assistant (Architecture, third year)
 title: Shakespeare and Scripture
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Spalding’s Glue: “Useful in Every House” and Every Confederate Campground.mdx
+++ b/content/posts/Spalding’s Glue: “Useful in Every House” and Every Confederate Campground.mdx
@@ -1,7 +1,7 @@
 ---
 author: Shivani Dimri
 title: "Spalding’s Glue: “Useful in Every House” and Every Confederate Campground?"
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Student Group Protests Faculty Ban on Preacher (1838).mdx
+++ b/content/posts/Student Group Protests Faculty Ban on Preacher (1838).mdx
@@ -1,7 +1,7 @@
 ---
 author: Rachel Gaffin, Undergraduate Research Assistant
 title: Student Group Protests Faculty Ban on Preacher (1838)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/The Anatomical Theatre (1825-1939).mdx
+++ b/content/posts/The Anatomical Theatre (1825-1939).mdx
@@ -1,7 +1,7 @@
 ---
 author: Dominic Puzio, Undergraduate Research Assistant (third year)
 title: The Anatomical Theatre (1825-1939)
-publish: true
+published: true
 category: Architecture
 ---
 

--- a/content/posts/The Chairman is Horsewhipped (Yet Receives Little Sympathy from the Student Body) (1839).mdx
+++ b/content/posts/The Chairman is Horsewhipped (Yet Receives Little Sympathy from the Student Body) (1839).mdx
@@ -1,7 +1,7 @@
 ---
 author: Thomas M. Winters, Graduate Research Assistant (Art History)
 title: The Chairman is Horsewhipped (Yet Receives Little Sympathy from the Student Body) (1839)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/The Court of the University (1826).mdx
+++ b/content/posts/The Court of the University (1826).mdx
@@ -1,7 +1,7 @@
 ---
 author: "Catherine A. Creighton, Undergraduate Research Assistant (History Degree) "
 title: The Court of the University (1826)
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/The Destinies of the South Must Be Entrusted to Our Keeping:                                     1850s Secessionist and Pro-Slavery Thought at the University of Virginia.mdx
+++ b/content/posts/The Destinies of the South Must Be Entrusted to Our Keeping:                                     1850s Secessionist and Pro-Slavery Thought at the University of Virginia.mdx
@@ -3,7 +3,7 @@ title: >-
   "The Destinies of the South Must Be Entrusted to Our Keeping": 1850s
   Secessionist and Pro-Slavery Thought at the University of Virginia
 author: Gwen Dilworth
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/The Enslaved Workers of Pavilion X.mdx
+++ b/content/posts/The Enslaved Workers of Pavilion X.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: "The Enslaved Workers of Pavilion X "
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/The Establishment of a University Dispensary (1826).mdx
+++ b/content/posts/The Establishment of a University Dispensary (1826).mdx
@@ -1,7 +1,7 @@
 ---
 author: "Catherine A. Creighton, Undergraduate Research Assistant (History Degree) "
 title: The Establishment of a University Dispensary (1826)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/The Faculty Forbids Cheating (1841).mdx
+++ b/content/posts/The Faculty Forbids Cheating (1841).mdx
@@ -1,7 +1,7 @@
 ---
 author: Emily Richards, Undergraduate Research Assistant (Architecture, 3rd year)
 title: The Faculty Forbids Cheating (1841)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/The Fifteen Hand Law at UVa.mdx
+++ b/content/posts/The Fifteen Hand Law at UVa.mdx
@@ -1,7 +1,7 @@
 ---
 author: Trevor Hazelwood
 title: The Fifteen Hand Law at UVa
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/The Place of Religion in the Early University.mdx
+++ b/content/posts/The Place of Religion in the Early University.mdx
@@ -1,7 +1,7 @@
 ---
 author: Connor Andrews
 title: The Place of Religion in the Early University
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/The Proctor, The University, and the Law (1825).mdx
+++ b/content/posts/The Proctor, The University, and the Law (1825).mdx
@@ -1,7 +1,7 @@
 ---
 author: "Catherine A. Creighton, Undergraduate Research Assistant (History Degree) "
 title: The Proctor, The University, and the Law (1825)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/The Shooting of John AG Davis: a Student's Perspective (1840).mdx
+++ b/content/posts/The Shooting of John AG Davis: a Student's Perspective (1840).mdx
@@ -1,7 +1,7 @@
 ---
 author: Ellen Adams
 title: "The Shooting of John A.G. Davis: a Student's Perspective (1840)"
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/The Temperance Movement at UVA.mdx
+++ b/content/posts/The Temperance Movement at UVA.mdx
@@ -1,7 +1,7 @@
 ---
 author: Brittany Acors
 title: The Temperance Movement at UVA
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/The UVa Cemetery.mdx
+++ b/content/posts/The UVa Cemetery.mdx
@@ -1,7 +1,7 @@
 ---
 author: Trevor Hazelwood
 title: The UVa Cemetery
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/The University of Virginia: Academic Incubator of the Lost Cause.mdx
+++ b/content/posts/The University of Virginia: Academic Incubator of the Lost Cause.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: "The University of Virginia: Academic Incubator of the Lost Cause?"
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/The Use of the Riot Act (1836).mdx
+++ b/content/posts/The Use of the Riot Act (1836).mdx
@@ -1,7 +1,7 @@
 ---
 author: Connor Andrews, Undergraduate Research Assistant (History, 3rd year)
 title: The Use of the Riot Act (1836)
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Typhoid Fever at the University (1829).mdx
+++ b/content/posts/Typhoid Fever at the University (1829).mdx
@@ -1,7 +1,7 @@
 ---
 author: Olivia Beatty, Undergraduate Research Assistant (History, 3rd Year)
 title: "Typhoid Fever at the University (1829) "
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/UVa Public Day puts students' brilliance on display.mdx
+++ b/content/posts/UVa Public Day puts students' brilliance on display.mdx
@@ -1,7 +1,7 @@
 ---
 author: Archie Holmes and William Sherman
 title: UVa Public Day puts students' brilliance on display
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Violent Resistance and Student Self-Governance: A History of Public Day.mdx
+++ b/content/posts/Violent Resistance and Student Self-Governance: A History of Public Day.mdx
@@ -1,7 +1,7 @@
 ---
 author: Millicent Usoro
 title: "Violent Resistance and Student Self-Governance: A History of Public Day"
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Virginia and the Secession Crisis, 1859-1861.mdx
+++ b/content/posts/Virginia and the Secession Crisis, 1859-1861.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: Virginia and the Secession Crisis, 1859-1861
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/Virginia’s Geography and Demographics, 1819-1861.mdx
+++ b/content/posts/Virginia’s Geography and Demographics, 1819-1861.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: Virginia’s Geography and Demographics, 1819-1861
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/Water at the University of Virginia from 1825-1850.mdx
+++ b/content/posts/Water at the University of Virginia from 1825-1850.mdx
@@ -1,7 +1,7 @@
 ---
 author: Meghan Ellwood
 title: Water at the University of Virginia from 1825-1850
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/What We Can Learn from the Letters of Thomas Hill Norwood.mdx
+++ b/content/posts/What We Can Learn from the Letters of Thomas Hill Norwood.mdx
@@ -1,7 +1,7 @@
 ---
 author: Lauren Johnson, Undergraduate Researcher
 title: What We Can Learn from the Letters of Thomas Hill Norwood
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/Woodrow Wilson's Virginia Education.mdx
+++ b/content/posts/Woodrow Wilson's Virginia Education.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ian Iverson
 title: "Woodrow Wilson's Virginia Education "
-publish: true
+published: true
 category: Contextualizing Essays
 ---
 

--- a/content/posts/“An Urgent Want of Additional Lecture Rooms”: University of Virginia Enrollment 1846-1861.mdx
+++ b/content/posts/“An Urgent Want of Additional Lecture Rooms”: University of Virginia Enrollment 1846-1861.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ben Hitchcock
 title: "“An Urgent Want of Additional Lecture Rooms”: University of Virginia Enrollment 1846-1861"
-publish: true
+published: true
 category: Daily Life
 ---
 

--- a/content/posts/“Something New, Romantic, and Sublime”: Weyer’s Cave and the University of Virginia.mdx
+++ b/content/posts/“Something New, Romantic, and Sublime”: Weyer’s Cave and the University of Virginia.mdx
@@ -1,7 +1,7 @@
 ---
 author: Ben Hitchcock
 title: "“Something New, Romantic, and Sublime”: Weyer’s Cave and the University of Virginia"
-publish: true
+published: true
 category: Daily Life
 ---
 


### PR DESCRIPTION
## What

Renames the `publish:` frontmatter key to `published:` across all 73 posts in `content/posts/`. Value (all currently `true`) is preserved.

## Why

Core Data Places v1.9.0 filters the posts feed (`/api/posts`) unconditionally by `published: true`. Posts in this repo currently use the old `publish:` key, which the upgraded site ignores — without this rename, all 73 posts would stop appearing after the v1.9.0 upgrade. The filter is intentional (tied to the Clerk-based draft / published workflow); the upgrade path for older content is to rename the key.

## Notes

- Surgical line-level rename only, no body or other-field changes.
- Generated with a small migration script (`scripts/migrations/v1.9.0-posts-published.mjs` in core-data-places — coming as a separate PR) so TinaCMS's frontmatter formatting is preserved exactly.

Related: core-data-places#623, core-data-places#635, core-data-places#636.